### PR TITLE
[FIX] set running=False when IOLoop stops

### DIFF
--- a/chopsticks/ioloop.py
+++ b/chopsticks/ioloop.py
@@ -302,4 +302,5 @@ class IOLoop:
             self.running = True
             while self.running and (self.read or self.write):
                 self.step()
+        self.stop(self.result)
         return self.result


### PR DESCRIPTION
Steps to reproduce:

1) Make a tunnel then close it - this ends the IOLoop as
   self.{read,write} are empty, but without calling `stop()`
2) Make another tunnel - stderr ioloop never starts running
   as it's still considered running https://github.com/amigrave/chopsticks/blob/master/chopsticks/tunnel.py#L51
   -> we never get the stderr

This error is hidden if the second tunnel is created before the first one is closed.